### PR TITLE
Support $ $ for inline maths

### DIFF
--- a/site/content/exercises/finite-differences.md
+++ b/site/content/exercises/finite-differences.md
@@ -9,18 +9,18 @@ Consider the one-dimensional Poisson equation with homogeneous Dirichlet conditi
 $$-\frac{d^2 u}{d x^2}=f(x),~~~x\in(0,1)$$
 with Dirichlet boundary conditions
 $$u(0)=u(1)  =  0.$$
-1. Discretise the Poisson equation by finite differences using an equidistant mesh size \(h=1/N\) and \(N+1\) grid points.
+1. Discretise the Poisson equation by finite differences using an equidistant mesh size $h=1/N$ and $N+1$ grid points.
 2. Write the finite difference approximation from 1. in matrix-vector form $Au=b$. Therefore, define the entries of the matrix $A\in\mathbb{R}^{N+1\times N+1}$.
-3. Write the finite difference approximation as \(Au=b\), where \(A\in\mathbb{R}^{N-1\times N-1}\) and \(b\in\mathbb{R}^{N-1}\), by substituting the values for \(u(0)\) and \(u(1)\).
+3. Write the finite difference approximation as $Au=b$, where $A\in\mathbb{R}^{N-1\times N-1}$ and $b\in\mathbb{R}^{N-1}$, by substituting the values for $u(0)$ and $u(1)$.
 
 
 # Eigenvalues and eigenvectors
 When analysing the properties of numerical algorithms it is often helpful to know about the spectrum (eigenvectors) of the operator being treated.
 A non-zero vector $x$ is an eigenvector of a matrix $A$ if and only if there exists a scalar $\lambda$ such that
 $$Ax=\lambda x.$$
-The scalar \(\lambda\) is the corresponding eigenvalue.
+The scalar $\lambda$ is the corresponding eigenvalue.
 
-Show that the discretised sine, i.e. \(u_i = sin(k\pi ih)\), is an eigenvector with eigenvalue \(\lambda=(4/h^2)\sin^2(k\pi h/2)\) of the finite difference matrix \(A\)
+Show that the discretised sine, i.e. $u_i = sin(k\pi ih)$, is an eigenvector with eigenvalue $\lambda=(4/h^2)\sin^2(k\pi h/2)$ of the finite difference matrix $A$
 in the previous exercise.
 
 You may find the following trigonometric identities useful:

--- a/site/themes/book/layouts/partials/docs/html-head.html
+++ b/site/themes/book/layouts/partials/docs/html-head.html
@@ -25,8 +25,20 @@
         src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js"
         integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4"
         crossorigin="anonymous"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js" integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa" crossorigin="anonymous"
-        onload="renderMathInElement(document.body);"></script>
+<script defer
+        src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js"
+        integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa"
+        crossorigin="anonymous"></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+      renderMathInElement(document.body, { delimiters : [
+          { left: "$$", right: "$$", display: true },
+          { left: "$", right: "$", display: false },
+          { left: "\\(", right: "\\)", display: false },
+          { left: "\\[", right: "\\]", display: true }
+      ] })
+  });
+</script>
 {{- end -}}
 
 {{ "<!--" | safeHTML }}


### PR DESCRIPTION
For strange reasons as well, one needs `\\( \\)` for inline maths with
parens.
